### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ subprojects {
         'org.springframework.integration:spring-integration-ftp:4.1.2.RELEASE',
 
         'xml-apis:xml-apis:2.0.2',
-        'commons-collections:commons-collections:3.2.1',
+        'commons-collections:commons-collections:3.2.2',
         'javax.servlet:javax.servlet-api:3.1.0',
 
         'org.projectlombok:lombok:1.16.2',

--- a/modules/sms/build.gradle
+++ b/modules/sms/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     compile  'javax.activation:activation:1.1.1',
             'org.springframework.integration:spring-integration-core:4.1.2.RELEASE',
             'org.springframework.integration:spring-integration-jdbc:4.1.2.RELEASE',
-            'commons-collections:commons-collections:3.2.1',
+            'commons-collections:commons-collections:3.2.2',
             'commons-lang:commons-lang:2.6',
             project(':modules:db')
 


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
